### PR TITLE
fix: Remove the secret key parameter to avoid overriding.

### DIFF
--- a/.github/workflows/paystackease-ci-cd.yml
+++ b/.github/workflows/paystackease-ci-cd.yml
@@ -99,4 +99,3 @@ jobs:
       if: steps.release.outputs.released == 'true'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
The secret key should be gotten using decouple and not being passed as a parameter.